### PR TITLE
Add support for build and base directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ It's possible to use `/usr/bin/gcov-7` and `/usr/bin/gcov-8`.
 
 **Required** Output path for the lcov info, by default `coverage.info`
 
+### `build_dir`
+
+**Required** Build directory (see lcov man for option -d)
+
+### `base_dir`
+
+**Required** Base directory (see lcov man for option -b)
+
 ## Outputs
 
 No outputs.

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,14 @@ inputs:
         description: 'Output lcov info file'
         required: true
         default: 'coverage.info'
+    build_dir:
+        description: 'Build directory (lcov -d)'
+        required: true
+        default: '.'
+    base_dir:
+        description: 'Base directory (lcov -b)'
+        required: true
+        default: '.'
 runs:
     using: 'docker'
     image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ cd $GITHUB_WORKSPACE
 mkdir -p $TEMP_LCOV_PATH
 
 # Generate the initial lcov version and strips out anything related to /usr
-/usr/bin/lcov --gcov-tool $INPUT_GCOV_PATH -c -d . -o $TEMP_LCOV_PATH/info
+/usr/bin/lcov --gcov-tool $INPUT_GCOV_PATH -c -d $INPUT_BUILD_DIR -b $INPUT_BASE_DIR -o $TEMP_LCOV_PATH/info
 /usr/bin/lcov --gcov-tool $INPUT_GCOV_PATH -r $TEMP_LCOV_PATH/info '/usr/*' -o $TEMP_LCOV_PATH/filtered
 
 if [ -n "$INPUT_REMOVE_PATTERNS" ];


### PR DESCRIPTION
Small improvements which allows to use it nicely with cmake-based projects. See https://github.com/rlalik/FitterFactory/blob/d02bc4afe2e7c0a9ed07926a6a56b20f7c744f6e/.github/workflows/coveralls.yml#L82 for example of usage.