### PR TITLE
To support Ubuntu 22.04 exclude gcc 7 and 8, as they are available add gcc 10, 11 and 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL "com.github.actions.description"="Action to run lcov"
 LABEL "com.github.actions.name"="lcov-action"
 LABEL "com.github.actions.color"="blue"
 
-RUN apt-get update && apt-get install -y cpp gcc cpp-7 gcc-7 cpp-8 gcc-8 cpp-9 gcc-9 lcov
+RUN apt-get update && apt-get install -y cpp gcc cpp-9 gcc-9 cpp-10 gcc-10 cpp-11 gcc-11 cpp-12 gcc-12 lcov
 
 COPY entrypoint.sh /
 


### PR DESCRIPTION
To support Ubuntu 22.04 exclude gcc 7 and 8, as they are available add gcc 10, 11 and 12