### PR TITLE
Switch to use a pre-built docker image from the github docker registry

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,4 @@ inputs:
         default: '.'
 runs:
     using: 'docker'
-    image: 'Dockerfile'
+    image: 'docker://ghcr.io/danielealbano/lcov-action:v3'


### PR DESCRIPTION
Switch to use a pre-built docker image from the github docker registry